### PR TITLE
Updates PYTHON_INC for Mac OSX Catalina

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -1,6 +1,6 @@
 SRILM_LIBS=/Users/nmadnani/work/srilm/lib/macosx
 SRILM_INC=/Users/nmadnani/work/srilm/include
-PYTHON_INC=/System/Library/Frameworks/Python.framework/Headers
+PYTHON_INC=/System/Library/Frameworks/Python.framework/Versions/2.7/Headers
 PERL_INC=/System/Library/Perl/5.18/darwin-thread-multi-2level/CORE
 
 python: clean _srilm.so


### PR DESCRIPTION
Simple update of the PYTHON_INC to the location of 2.7 header files on Mac OSX Catalina 10.15.7. 

However, running it with any 3.x installations (installed from pyenv) in tandem with swig for Python 3 produces the following error:
```
"_PyBytes_AsStringAndSize", referenced from:
      SWIG_AsCharPtrAndSize(_object*, char**, unsigned long*, int*) in srilm_python_wrap.o
  "_PyInstanceMethod_New", referenced from:
      SWIG_PyInstanceMethod_New(_object*, _object*) in srilm_python_wrap.o
  "_PyModule_Create2", referenced from:
      _PyInit__srilm in srilm_python_wrap.o
  "_PyUnicode_AsUTF8String", referenced from:
      SWIG_AsCharPtrAndSize(_object*, char**, unsigned long*, int*) in srilm_python_wrap.o
  "_PyUnicode_Concat", referenced from:
      SwigPyObject_repr(SwigPyObject*) in srilm_python_wrap.o
  "_PyUnicode_DecodeUTF8", referenced from:
      SWIG_FromCharPtrAndSize(char const*, unsigned long) in srilm_python_wrap.o
  "_PyUnicode_FromFormat", referenced from:
      SwigPyPacked_repr(SwigPyPacked*) in srilm_python_wrap.o
      SwigPyPacked_str(SwigPyPacked*) in srilm_python_wrap.o
      SwigPyObject_repr(SwigPyObject*) in srilm_python_wrap.o
  "_PyUnicode_FromString", referenced from:
      SWIG_Python_str_FromChar(char const*) in srilm_python_wrap.o
```